### PR TITLE
Update regex for better matching URL

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,7 +10,7 @@ import { LinkHandler } from './api'
 export class URLHandler extends LinkHandler {
     // From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
     // See : https://stackoverflow.com/questions/6927719/url-regex-does-not-work-in-javascript
-    regex = '\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))'
+    regex = '\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
 
     constructor (private electron: ElectronService) {
         super()

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -8,7 +8,9 @@ import { LinkHandler } from './api'
 
 @Injectable()
 export class URLHandler extends LinkHandler {
-    regex = 'http(s)?://[^\\s;\'"]+[^,;\\s]'
+    // From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
+    // See : https://stackoverflow.com/questions/6927719/url-regex-does-not-work-in-javascript
+    regex = '\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))'
 
     constructor (private electron: ElectronService) {
         super()


### PR DESCRIPTION
Hi, first thanks to for making terminus, it's an awesome tool !

I do this PR to improve regex matching for url, so it's fixes #4 and matches others url style like wihtout `http(s)`.

New regex can be tested at : https://regex101.com/r/h0LlIW/1/

Inspired from https://daringfireball.net/2010/07/improved_regex_for_matching_urls
Thanks to https://stackoverflow.com/questions/6927719/url-regex-does-not-work-in-javascript

