### PR TITLE
refactored regex path detection for windows & unix

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -25,7 +25,8 @@ export class URLHandler extends LinkHandler {
 
 @Injectable()
 export class UnixFileHandler extends LinkHandler {
-    regex = /[~/][^\s,;'"]+/
+    // Only absolute and home paths
+    regex = /(\/|~)+(\.|)[\w\/-]+(\.[\w]+|)/
 
     constructor (
         private toastr: ToastrService,
@@ -50,7 +51,8 @@ export class UnixFileHandler extends LinkHandler {
 
 @Injectable()
 export class WindowsFileHandler extends LinkHandler {
-    regex = /\\w:[^\\s,;/\'"]+/
+    // Only absolute and home paths
+    regex = /(([a-zA-Z]:|\\|~)\\[\w\-()\\\.]+|"([a-zA-Z]:|\\)\\[\w\s\-()\\\.]+")/
 
     constructor (
         private toastr: ToastrService,
@@ -60,7 +62,8 @@ export class WindowsFileHandler extends LinkHandler {
     }
 
     convert (uri: string): string {
-        return untildify(uri)
+        const sanitizedUri = uri.replace(/"/g, '')
+        return untildify(sanitizedUri)
     }
 
     handle (uri: string) {


### PR DESCRIPTION
Both RegExp where not covering the usual file paths. In case of the windows RegExp it was 100% non-functional. I added paths detection for absolute and home paths for both platforms.

__Testcases:__
Unix: https://regexr.com/4hnq7
Windows: https://regexr.com/4hnkp

Windows paths are a bit tricky due to the spaces, my take on it is to copy what ConEmu does and require doublquotes before/after the path containing spaces. Another thing that I don't know how to solve (still not very familiar with your codebase only been a day 😅 ) is how we could resolve relative paths. VScode keeps track of the cwd, and I guess you do as well ? Because then we simply can join the paths and get the absolute one 🎉 